### PR TITLE
Readd missing controls on duplicate default_code

### DIFF
--- a/product_sequence/models/product_product.py
+++ b/product_sequence/models/product_product.py
@@ -22,6 +22,18 @@
 from openerp import models, fields, api
 from openerp.tools.translate import _
 
+def update_null_and_slash_codes(cr):  # pragma: no cover
+        #Copied from 
+        """
+        Updates existing codes matching the default '/' or
+        empty. Primarily this ensures installation does not
+        fail for demo data.
+        :param cr: database cursor
+        :return: void
+        """
+        cr.execute("UPDATE product_product "
+                   "SET default_code = '!!mig!!' || id "
+                   "WHERE default_code IS NULL OR default_code = '/';")
 
 def update_null_and_slash_codes(cr):  # pragma: no cover
     """


### PR DESCRIPTION
Those part dispappeared from the PR and was present in the OCA repo.
This code reintegrate the missing part
https://github.com/OCA/product-attribute/pull/57#issuecomment-133349162

Replacement of https://github.com/pedrobaeza/product-attribute/pull/1
